### PR TITLE
Updating main.go - Explicit JSON output and quiet mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.a
+*.so
+*.exe
+.DS_Store
+go-get-proxied

--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ func main() {
 
 #### Command Line Usage:
 ```bash
-> ./proxymain -h                                                                                                                  Tue Oct 23 10:01:44 2018
-Usage of ./proxymain:
+> ./go-get-proxied -h
+Usage of ./go-get-proxied:
   -c string
     	Optional. Path to configuration file.
+  -j	Optional. If a proxy is found, write it as JSON instead of a URL.
   -p string
     	Optional. The proxy protocol you wish to lookup. Default: https (default "https")
-  -q	Optional. Quiet mode; only write the URL of a proxy to stdout (if found). Default: false
   -t string
     	Optional. Target URL which the proxy will be used for. Default: *
+  -v	Optional. If set, log content will be sent to stderr.
 ```
 ```bash
 > netsh winhttp set proxy testProxy:8999
@@ -45,7 +46,9 @@ Current WinHTTP proxy settings:
 
     Proxy Server(s) :  testProxy:8999
     Bypass List     :  (none)
-> ./proxymain.exe
+> ./go-get-proxied
+https://testProxy:8999
+> ./go-get-proxied -j
 {
    "host": "testProxy",
    "password": null,
@@ -54,14 +57,12 @@ Current WinHTTP proxy settings:
    "src": "WinHTTP:WinHttpDefault",
    "username": null
 }
-> ./proxy_main.exe -q
-https://testProxy:8999
 ```
 ```bash
 > echo '{"https":"testProxy:8999"}' > proxy.config
-> ./proxymain -c proxy.config -q
+> ./go-get-proxied -c proxy.config
 https://testProxy:8999
-> ./proxymain -c proxy.config
+> ./go-get-proxied -c proxy.config -j
 {
    "host": "testProxy",
    "password": null,

--- a/main.go
+++ b/main.go
@@ -26,13 +26,15 @@ func main() {
 	protocolP := flag.String("p", "https", "Optional. The proxy protocol you wish to lookup. Default: https")
 	configP := flag.String("c", "", "Optional. Path to configuration file.")
 	targetP := flag.String("t", "", "Optional. Target URL which the proxy will be used for. Default: *")
-	quietP := flag.Bool("q", false, "Optional. Quiet mode; only write the URL of a proxy to stdout (if found). Default: false")
+	jsonP := flag.Bool("j", false, "Optional. If a proxy is found, write it as JSON instead of a URL.")
+	verboseP := flag.Bool("v", false, "Optional. If set, log content will be sent to stderr.")
 	flag.Parse()
 	var (
 		protocol string
 		config   string
 		target   string
-		quiet    bool
+		jsonOut  bool
+		verbose  bool
 	)
 	if protocolP != nil {
 		protocol = *protocolP
@@ -43,16 +45,21 @@ func main() {
 	if targetP != nil {
 		target = *targetP
 	}
-	if quietP != nil {
-		quiet = *quietP
+	if jsonP != nil {
+		jsonOut = *jsonP
 	}
-	if quiet {
+	if verboseP != nil {
+		verbose = *verboseP
+	}
+	if verbose {
+		log.SetOutput(os.Stderr)
+	} else {
 		log.SetOutput(ioutil.Discard)
 	}
 	p := proxy.NewProvider(config).Get(protocol, target)
 	var exit int
 	if p != nil {
-		if !quiet {
+		if jsonOut {
 			b, _ := json.MarshalIndent(p, "", "   ")
 			fmt.Println(string(b))
 		} else {
@@ -60,9 +67,6 @@ func main() {
 		}
 	} else {
 		exit = 1
-		if !quiet {
-			println("Proxy: nil")
-		}
 	}
 	os.Exit(exit)
 }


### PR DESCRIPTION
* Default output now just contains the URL
* JSON output can be requested via `-j`
* Verbose output can be requested, which is sent to stderr

```
> ./go-get-proxied -h
Usage of ./go-get-proxied:
  -c string
    	Optional. Path to configuration file.
  -j	Optional. If a proxy is found, write it as JSON instead of a URL.
  -p string
    	Optional. The proxy protocol you wish to lookup. Default: https (default "https")
  -t string
    	Optional. Target URL which the proxy will be used for. Default: *
  -v	Optional. If set, log content will be sent to stderr.
```
```
> ./go-get-proxied -c proxy.config
https://testProxy:8999
```
```
> ./go-get-proxied -c proxy.config -j
{
   "host": "testProxy",
   "password": null,
   "port": 8999,
   "protocol": "https",
   "src": "ConfigurationFile",
   "username": null
}
```