### PR TITLE
Removing date from log output

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func main() {
 		verbose = *verboseP
 	}
 	if verbose {
+		log.SetFlags(0)
 		log.SetOutput(os.Stderr)
 	} else {
 		log.SetOutput(ioutil.Discard)


### PR DESCRIPTION
Removes timestamp from log output as this is not necessary when running from main.
i.e.
```
./go-get-proxied -v
[proxy.Provider.readDarwinNetworkSettingProxy]: https proxy is not enabled.
```