### PR TITLE
Adds ability to set custom timeouts for a given provider

### DIFF
--- a/proxy/provider.go
+++ b/proxy/provider.go
@@ -146,16 +146,17 @@ func (p *provider) init(configFile string) {
 
 /*
 Set the timeouts used by this provider making a call which requires external resources (i.e. WPAD/PAC).
-Should any of these timeouts be exceeded, that particular call will be cancelled. To this end,
-this timeout does not represent the complete timeout for any call to this provider, but rather are applied
-to individual implementations uniquely.
+Should any of these timeouts be exceeded, that particular call will be cancelled.
+To this end, this timeout does not represent the complete timeout for any call to this provider,
+but rather are applied to individual implementations uniquely.
+Additionally, this timeout is not guaranteed to be respected by the implementation, and may vary.
 Params:
-	resolve: Time in milliseconds to use for name resolution.
-	connect: Time in milliseconds to use for server connection requests.
+	resolve: Time in milliseconds to use for name resolution. Provider default is 5000.
+	connect: Time in milliseconds to use for server connection requests. Provider default is 5000.
 			 TCP/IP can time out while setting up the socket during the
 			 three leg SYN/ACK exchange, regardless of the value of this parameter.
-	send: Time in milliseconds to use for sending requests.
-	receive: Time in milliseconds to receive a response to a request.
+	send: Time in milliseconds to use for sending requests. Provider default is 20000.
+	receive: Time in milliseconds to receive a response to a request. Provider default is 20000.
 */
 func (p *provider) SetTimeouts(resolve int, connect int, send int, receive int) {
 	p.resolveTimeout = resolve

--- a/proxy/provider.go
+++ b/proxy/provider.go
@@ -82,23 +82,42 @@ type Provider interface {
 			nil: A proxy was not found, or an error occurred.
 	*/
 	GetSOCKSProxy(targetUrl string) Proxy
+	/*
+		Set the timeouts used by this provider making a call which requires external resources (i.e. WPAD/PAC).
+		Should any of these timeouts be exceeded, that particular call will be cancelled.
+		To this end, this timeout does not represent the complete timeout for any call to this provider,
+		but rather are applied to individual implementations uniquely.
+		Additionally, this timeout is not guaranteed to be respected by the implementation, and may vary.
+		Params:
+			resolve: Time in milliseconds to use for name resolution. Provider default is 5000.
+			connect: Time in milliseconds to use for server connection requests. Provider default is 5000.
+					 TCP/IP can time out while setting up the socket during the
+					 three leg SYN/ACK exchange, regardless of the value of this parameter.
+			send: Time in milliseconds to use for sending requests. Provider default is 20000.
+			receive: Time in milliseconds to receive a response to a request. Provider default is 20000.
+	*/
+	SetTimeouts(resolve int, connect int, send int, receive int)
 }
 
 const (
-	protocolHTTP         = "http"
-	protocolHTTPS        = "https"
-	protocolFTP          = "ftp"
-	protocolSOCKS        = "socks"
-	proxyKeyFormat       = "%s_PROXY"
-	noProxyKeyUpper      = "NO_PROXY"
-	noProxyKeyLower      = "no_proxy"
-	prefixSOCKS          = protocolSOCKS
-	prefixAll            = "all"
-	targetUrlWildcard    = "*"
-	domainDelimiter      = "."
-	bypassLocal          = "<local>"
-	srcConfigurationFile = "ConfigurationFile"
-	srcEnvironmentFmt    = "Environment[%s]"
+	protocolHTTP          = "http"
+	protocolHTTPS         = "https"
+	protocolFTP           = "ftp"
+	protocolSOCKS         = "socks"
+	proxyKeyFormat        = "%s_PROXY"
+	noProxyKeyUpper       = "NO_PROXY"
+	noProxyKeyLower       = "no_proxy"
+	prefixSOCKS           = protocolSOCKS
+	prefixAll             = "all"
+	targetUrlWildcard     = "*"
+	domainDelimiter       = "."
+	bypassLocal           = "<local>"
+	srcConfigurationFile  = "ConfigurationFile"
+	srcEnvironmentFmt     = "Environment[%s]"
+	defaultResolveTimeout = 5000
+	defaultConnectTimeout = 5000
+	defaultSendTimeout    = 20000
+	defaultReceiveTimeout = 20000
 )
 
 type getEnvAdapter func(string) string
@@ -106,15 +125,43 @@ type getEnvAdapter func(string) string
 type commandAdapter func(context.Context, string, ...string) *exec.Cmd
 
 type provider struct {
-	configFile string
-	getEnv     getEnvAdapter
-	proc       commandAdapter
+	configFile     string
+	getEnv         getEnvAdapter
+	proc           commandAdapter
+	resolveTimeout int
+	connectTimeout int
+	sendTimeout    int
+	receiveTimeout int
 }
 
 func (p *provider) init(configFile string) {
 	p.configFile = configFile
 	p.getEnv = os.Getenv
 	p.proc = exec.CommandContext
+	p.resolveTimeout = defaultResolveTimeout
+	p.connectTimeout = defaultConnectTimeout
+	p.sendTimeout = defaultSendTimeout
+	p.receiveTimeout = defaultReceiveTimeout
+}
+
+/*
+Set the timeouts used by this provider making a call which requires external resources (i.e. WPAD/PAC).
+Should any of these timeouts be exceeded, that particular call will be cancelled. To this end,
+this timeout does not represent the complete timeout for any call to this provider, but rather are applied
+to individual implementations uniquely.
+Params:
+	resolve: Time in milliseconds to use for name resolution.
+	connect: Time in milliseconds to use for server connection requests.
+			 TCP/IP can time out while setting up the socket during the
+			 three leg SYN/ACK exchange, regardless of the value of this parameter.
+	send: Time in milliseconds to use for sending requests.
+	receive: Time in milliseconds to receive a response to a request.
+*/
+func (p *provider) SetTimeouts(resolve int, connect int, send int, receive int) {
+	p.resolveTimeout = resolve
+	p.connectTimeout = connect
+	p.sendTimeout = send
+	p.receiveTimeout = receive
 }
 
 /*

--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -277,7 +277,7 @@ func (p *providerWindows) getProxyInfoForUrl(targetUrl *url.URL, autoProxyOption
 		return nil, err
 	}
 	defer p.closeHandle(h)
-	err = winhttp.SetTimeouts(h, 60000, 60000, 30000, 30000)
+	err = winhttp.SetTimeouts(h, p.resolveTimeout, p.connectTimeout, p.sendTimeout, p.receiveTimeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The following functionality has been added:
```
/*
	Set the timeouts used by this provider making a call which requires external resources (i.e. WPAD/PAC).
	Should any of these timeouts be exceeded, that particular call will be cancelled.
	To this end, this timeout does not represent the complete timeout for any call to this provider,
	but rather are applied to individual implementations uniquely.
	Additionally, this timeout is not guaranteed to be respected by the implementation, and may vary.
	Params:
		resolve: Time in milliseconds to use for name resolution. Provider default is 5000.
		connect: Time in milliseconds to use for server connection requests. Provider default is 5000.
				 TCP/IP can time out while setting up the socket during the
				 three leg SYN/ACK exchange, regardless of the value of this parameter.
		send: Time in milliseconds to use for sending requests. Provider default is 20000.
		receive: Time in milliseconds to receive a response to a request. Provider default is 20000.
*/
SetTimeouts(resolve int, connect int, send int, receive int)
```
Example:
```
provider = proxy.NewProvider("")
provider.SetTimeouts(5000, 5000, 20000, 20000)
provider.GetHTTPS("*")
```