### PR TITLE
Fix unit test so it's not affectd by the error message format of go version

### DIFF
--- a/proxy/provider_test.go
+++ b/proxy/provider_test.go
@@ -254,7 +254,7 @@ var dataProviderParseEnvHTTPSProxy = []struct {
 	{"HTTPS://test:8080", newTestProxy("https", "test", 8080, nil, "Environment[Key]"), nil},
 	{"test:8999", newTestProxy("", "test", 8999, nil, "Environment[Key]"), nil},
 	// Invalid
-	{"://test:8080", nil, errors.New("parse \"://test:8080\": missing protocol scheme")},
+	{"://test:8080", nil, errors.New("missing protocol scheme")},
 	// TODO These error cases are introduced after Go 1.7
 	//{"https", "https://[test:8080", nil, errors.New("parse https://[test:8080: missing ']' in host")},
 	//{"https", "https://username:1412¶45124@test:8080", nil, errors.New("parse https://username:1412¶45124@test:8080: net/url: invalid userinfo")},
@@ -280,7 +280,7 @@ func TestProvider_ParseEnvProxy(t *testing.T) {
 				a.Nil(err)
 			} else {
 				if a.NotNil(err) {
-					a.Equal(tt.expectError.Error(), err.Error())
+					a.Contains(err.Error(), tt.expectError.Error())
 				}
 			}
 		})
@@ -300,7 +300,7 @@ var dataProviderParseEnvURL = []struct {
 	{"", nil, new(notFoundError)},
 	{"   ", nil, new(notFoundError)},
 	// Invalid
-	{"://test:8080", nil, errors.New("parse \"://test:8080\": missing protocol scheme")},
+	{"://test:8080", nil, errors.New("missing protocol scheme")},
 	// TODO These error cases are introduced after Go 1.7
 	//{"https://[test:8080", nil, errors.New("parse https://[test:8080: missing ']' in host")},
 	//{"https://username:1412¶45124@test:8080", nil, errors.New("parse https://username:1412¶45124@test:8080: net/url: invalid userinfo")},
@@ -327,7 +327,7 @@ func TestProvider_ConfigProviderParseEnvURL(t *testing.T) {
 				a.Nil(err)
 			} else {
 				if a.NotNil(err) {
-					a.Equal(tt.expectError.Error(), err.Error())
+					a.Contains(err.Error(), tt.expectError.Error())
 				}
 			}
 		})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -77,12 +77,12 @@ var dataNewProxy = []struct {
 	// Invalid port
 	{
 		&url.URL{Scheme: "https", Host: "testProxy:testPort"},
-		nil, errors.New("SplitHostPort \"testProxy:testPort\": strconv.ParseUint: parsing \"testPort\": invalid syntax"),
+		nil, errors.New("strconv.ParseUint: parsing \"testPort\": invalid syntax"),
 	},
 	// Negative port
 	{
 		&url.URL{Scheme: "https", Host: "testProxy:-1"},
-		nil, errors.New("SplitHostPort \"testProxy:-1\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
+		nil, errors.New("strconv.ParseUint: parsing \"-1\": invalid syntax"),
 	},
 	// Empty host
 	{
@@ -116,7 +116,7 @@ func TestNewProxy(t *testing.T) {
 				a.Nil(err)
 			} else {
 				if a.NotNil(err) {
-					a.Equal(tt.expectErr.Error(), err.Error())
+					a.Contains(err.Error(), tt.expectErr.Error())
 				}
 			}
 		})

--- a/proxy/url_test.go
+++ b/proxy/url_test.go
@@ -48,7 +48,7 @@ var dataParseURL = []struct {
 	{"", "", &url.URL{}, nil},
 	{"", "https", &url.URL{Scheme: "https"}, nil},
 	// Invalid cases
-	{"://test:8080", "", nil, errors.New("parse \"://test:8080\": missing protocol scheme")},
+	{"://test:8080", "", nil, errors.New("missing protocol scheme")},
 	// TODO These error cases are introduced after Go 1.7
 	//{"https://[test:8080", "", nil, errors.New("parse https://[test:8080: missing ']' in host")},
 	//{"https://username:1412¶45124@test:8080", "", nil, errors.New("parse https://username:1412¶45124@test:8080: net/url: invalid userinfo")},
@@ -68,7 +68,7 @@ func TestParseURL(t *testing.T) {
 				a.Nil(err)
 			} else {
 				if a.NotNil(err) {
-					a.Equal(tt.expectError.Error(), err.Error())
+					a.Contains(err.Error(), tt.expectError.Error())
 				}
 			}
 		})
@@ -166,13 +166,13 @@ var dataSplitHostPort = []struct {
 	// port Max
 	{&url.URL{Host: "test:65535"}, "test", 65535, nil},
 	// Invalid - port NaN
-	{&url.URL{Host: "test1:test2"}, "", 0, errors.New("SplitHostPort \"test1:test2\": strconv.ParseUint: parsing \"test2\": invalid syntax")},
+	{&url.URL{Host: "test1:test2"}, "", 0, errors.New("strconv.ParseUint: parsing \"test2\": invalid syntax")},
 	// Invalid - port Exceeded
-	{&url.URL{Host: "test1:65536"}, "", 0, errors.New("SplitHostPort \"test1:65536\": strconv.ParseUint: parsing \"65536\": value out of range")},
+	{&url.URL{Host: "test1:65536"}, "", 0, errors.New("strconv.ParseUint: parsing \"65536\": value out of range")},
 	// Invalid - port signed
-	{&url.URL{Host: "test1:-1"}, "", 0, errors.New("SplitHostPort \"test1:-1\": strconv.ParseUint: parsing \"-1\": invalid syntax")},
+	{&url.URL{Host: "test1:-1"}, "", 0, errors.New("strconv.ParseUint: parsing \"-1\": invalid syntax")},
 	// Invalid - nil URL
-	{nil, "", 0, errors.New("SplitHostPort \"nil\": nil URL")},
+	{nil, "", 0, errors.New("nil URL")},
 }
 
 func TestSplitHostPort(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSplitHostPort(t *testing.T) {
 				a.Nil(err)
 			} else {
 				if a.NotNil(err) {
-					a.Equal(tt.expectErr.Error(), err.Error())
+					a.Contains(err.Error(),tt.expectErr.Error())
 				}
 			}
 		})


### PR DESCRIPTION
It was noticed that the error message format between go version (tested on 1.7.1 and 1.16.3) was different and because unit test was using string equals, it caused several test to pass/fail inconsistently between versions. This PR changed these unit test that depends on error message to use contains so it only tests for the section of the message that's defined in the code.
