### PR TITLE
Fix an issue where undefined proxy in autoconfig could cause a panic …

### DIFF
--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -14,8 +14,6 @@ package proxy
 
 import (
 	"github.com/rapid7/go-get-proxied/winhttp"
-	"fmt"
-	"strconv"
 	"log"
 	"net/url"
 	"reflect"
@@ -359,7 +357,6 @@ Returns:
 func (p *providerWindows) parseLpszProxy(protocol string, lpszProxy string) []string {
 	proxies := []string{}
 	lpszProxy = strings.TrimSpace(lpszProxy)
-	fmt.Println(lpszProxy + strconv.Itoa(len(lpszProxy)))
 	if len(lpszProxy) == 0 {
 		return proxies
 	}

--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -14,6 +14,8 @@ package proxy
 
 import (
 	"github.com/rapid7/go-get-proxied/winhttp"
+	"fmt"
+	"strconv"
 	"log"
 	"net/url"
 	"reflect"
@@ -356,11 +358,19 @@ Returns:
 //noinspection SpellCheckingInspection
 func (p *providerWindows) parseLpszProxy(protocol string, lpszProxy string) []string {
 	proxies := []string{}
+	lpszProxy = strings.TrimSpace(lpszProxy)
+	fmt.Println(lpszProxy + strconv.Itoa(len(lpszProxy)))
+	if len(lpszProxy) == 0 {
+		return proxies
+	}
 	for _, s := range strings.Split(lpszProxy, ";") {
 		parts := strings.SplitN(s, "=", 2)
 		// Include the proxy if protocol matches or if no protocol is specified
-		if len(parts) < 2 || strings.TrimSpace(parts[0]) == protocol {
+		if len(parts) < 2 {
+			// Assign a match, but keep looking in case we have a protocol specific match
 			proxies = append(proxies, s)
+		} else if strings.TrimSpace(parts[0]) == protocol {
+			proxies = append(proxies, parts[1])
 		}
 	}
 	return proxies

--- a/proxy/provider_windows_test.go
+++ b/proxy/provider_windows_test.go
@@ -20,14 +20,14 @@ import (
 
 var dataProviderWindowsParseLpszProxy = []struct {
 	lpszProxy string
-	expect    string
+	expect    []string
 }{
-	{"1.2.3.4:8443", "1.2.3.4:8443"},
-	{"1.2.3.4:8443;4.5.6.7:8999", "4.5.6.7:8999"},
-	{"1.2.3.4:8443;http=4.5.6.7:8999", "1.2.3.4:8443"},
-	{"http=1.2.3.4:8443;https=4.5.6.7:8999", "4.5.6.7:8999"},
-	{"", ""},
-	{"  ", "  "},
+	{"1.2.3.4:8443", []string{"1.2.3.4:8443"}},
+	{"1.2.3.4:8443;4.5.6.7:8999", []string{"1.2.3.4:8443","4.5.6.7:8999"}},
+	{"1.2.3.4:8443;http=4.5.6.7:8999", []string{"1.2.3.4:8443"}},
+	{"http=1.2.3.4:8443;https=4.5.6.7:8999", []string{"4.5.6.7:8999"}},
+	{"", []string{}},
+	{"  ", []string{}},
 }
 
 func TestProviderWindows_ParseLpszProxy(t *testing.T) {


### PR DESCRIPTION
…and prevent winhttp proxy from being checked

See issue https://github.com/rapid7/go-get-proxied/issues/24