### PR TITLE
Fix panic in GetProxy() on Windows, when proxy is undefined

### DIFF
--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -55,6 +55,9 @@ func (p *providerWindows) GetProxy(protocol string, targetUrlStr string) Proxy {
 		return proxy
 	}
 	proxies := p.readWinHttpProxy(protocol, targetUrl)
+	if len(proxies) == 0 {
+		return nil
+	}
 	return proxies[len(proxies) - 1]
 }
 


### PR DESCRIPTION
## Description
GetProxy() has no bounds checking, and panics when all detection methods return nothing.

## Testing
Call GetProxy() when proxy is not defined. It should return `nil` now.