### PR TITLE
Optional logging in provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/rapid7/go-get-proxied/proxy"
-	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/rapid7/go-get-proxied/proxy"
 )
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 		target   string
 		jsonOut  bool
 		verbose  bool
-		useList bool
+		useList  bool
 	)
 	if protocolP != nil {
 		protocol = *protocolP
@@ -54,19 +54,18 @@ func main() {
 	if verboseP != nil {
 		verbose = *verboseP
 	}
-	if verbose {
-		log.SetFlags(0)
-		log.SetOutput(os.Stderr)
-	} else {
-		log.SetOutput(ioutil.Discard)
-	}
 	if useListP != nil {
 		useList = *useListP
 	}
 	var exit int
 
+	log.SetFlags(0)
+	log.SetOutput(os.Stderr)
+
+	provider := proxy.NewProvider(config)
+	provider.SetLog(verbose)
 	if useList {
-		ps := proxy.NewProvider(config).GetProxies(protocol, target)
+		ps := provider.GetProxies(protocol, target)
 		if ps != nil {
 			if jsonOut {
 				b, _ := json.MarshalIndent(ps, "", "   ")
@@ -80,7 +79,7 @@ func main() {
 			exit = 1
 		}
 	} else {
-		p := proxy.NewProvider(config).GetProxy(protocol, target)
+		p := provider.GetProxy(protocol, target)
 		if p != nil {
 			if jsonOut {
 				b, _ := json.MarshalIndent(p, "", "   ")

--- a/proxy/provider.go
+++ b/proxy/provider.go
@@ -184,6 +184,10 @@ func (p *provider) SetLog(log bool) {
 	p.enableLogging = log
 }
 
+/*
+	Format and log a string. Will only log if logging is enabled on the provider.
+	Arguments are handled in the manner of fmt.Printf.
+*/
 func (p *provider) log(format string, v ...interface{}) {
 	if p.enableLogging {
 		log.Printf(format, v...)

--- a/proxy/provider.go
+++ b/proxy/provider.go
@@ -98,6 +98,13 @@ type Provider interface {
 	*/
 	SetTimeouts(resolve int, connect int, send int, receive int)
 	GetProxies(protocol string, targetUrl string) []Proxy
+
+	/*
+		Set whether the provider should log or not.
+		Params:
+			log: True to enable logging, false to disable logging. Provider default is true.
+	*/
+	SetLog(log bool)
 }
 
 const (
@@ -133,6 +140,7 @@ type provider struct {
 	connectTimeout int
 	sendTimeout    int
 	receiveTimeout int
+	enableLogging  bool
 }
 
 func (p *provider) init(configFile string) {
@@ -143,6 +151,7 @@ func (p *provider) init(configFile string) {
 	p.connectTimeout = defaultConnectTimeout
 	p.sendTimeout = defaultSendTimeout
 	p.receiveTimeout = defaultReceiveTimeout
+	p.enableLogging = true
 }
 
 /*
@@ -164,6 +173,21 @@ func (p *provider) SetTimeouts(resolve int, connect int, send int, receive int) 
 	p.connectTimeout = connect
 	p.sendTimeout = send
 	p.receiveTimeout = receive
+}
+
+/*
+	Set whether the provider should log or not.
+	Params:
+		log: True to log, false to not log. Provider default is true.
+*/
+func (p *provider) SetLog(log bool) {
+	p.enableLogging = log
+}
+
+func (p *provider) log(format string, v ...interface{}) {
+	if p.enableLogging {
+		log.Printf(format, v...)
+	}
 }
 
 /*
@@ -196,7 +220,7 @@ Returns:
 func (p *provider) readConfigFileProxy(protocol string) Proxy {
 	proxyJson, err := p.unmarshalProxyConfigFile()
 	if err != nil {
-		log.Printf("[proxy.Provider.readConfigFileProxy]: %s\n", err)
+		p.log("[proxy.Provider.readConfigFileProxy]: %s\n", err)
 		return nil
 	}
 	uStr, exists := proxyJson[protocol]
@@ -209,7 +233,7 @@ func (p *provider) readConfigFileProxy(protocol string) Proxy {
 		uProxy, uErr = NewProxy(uUrl, srcConfigurationFile)
 	}
 	if uErr != nil {
-		log.Printf("[proxy.Provider.readConfigFileProxy]: invalid config file proxy, skipping \"%s\": \"%s\"\n", protocol, uStr)
+		p.log("[proxy.Provider.readConfigFileProxy]: invalid config file proxy, skipping \"%s\": \"%s\"\n", protocol, uStr)
 		return nil
 	}
 	return uProxy
@@ -282,7 +306,7 @@ K:
 		proxy, err := p.parseEnvProxy(key)
 		if err != nil {
 			if !isNotFound(err) {
-				log.Printf("[proxy.Provider.readSystemEnvProxy]: failed to parse \"%s\" value: %s\n", key, err)
+				p.log("[proxy.Provider.readSystemEnvProxy]: failed to parse \"%s\" value: %s\n", key, err)
 			}
 			continue
 		}
@@ -292,7 +316,7 @@ K:
 				continue
 			}
 			bypass = p.isProxyBypass(targetUrl, proxyBypass, ",")
-			log.Printf("[proxy.Provider.readSystemEnvProxy]: \"%s\"=\"%s\", targetUrl=%s, bypass=%t", noProxyKey, proxyBypass, targetUrl, bypass)
+			p.log("[proxy.Provider.readSystemEnvProxy]: \"%s\"=\"%s\", targetUrl=%s, bypass=%t", noProxyKey, proxyBypass, targetUrl, bypass)
 			if bypass {
 				continue K
 			}

--- a/proxy/provider_darwin.go
+++ b/proxy/provider_darwin.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"regexp"
 	"strings"
@@ -146,11 +145,11 @@ func (p *providerDarwin) readDarwinNetworkSettingProxy(protocol string, targetUr
 	proxy, err := p.parseScutildata(protocol, targetUrl, scUtilBinary, scUtilBinaryArgument)
 	if err != nil {
 		if isNotFound(err) {
-			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: %s proxy is not enabled.\n", protocol)
+			p.log("[proxy.Provider.readDarwinNetworkSettingProxy]: %s proxy is not enabled.\n", protocol)
 		} else if isTimedOut(err) {
-			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: Operation timed out. \n")
+			p.log("[proxy.Provider.readDarwinNetworkSettingProxy]: Operation timed out. \n")
 		} else {
-			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: Failed to parse Scutil data, %s\n", err)
+			p.log("[proxy.Provider.readDarwinNetworkSettingProxy]: Failed to parse Scutil data, %s\n", err)
 		}
 	}
 	return proxy
@@ -265,7 +264,7 @@ func (p *providerDarwin) parseScutildata(protocol string, targetUrl *url.URL, na
 	}
 	if proxyBypass != "" {
 		bypass := p.isProxyBypass(targetUrl, proxyBypass, ",")
-		log.Printf("[proxy.Provider.parseProxyInfo]: ProxyBypass=\"%s\", targetUrl=%s, bypass=%t", proxyBypass, targetUrl, bypass)
+		p.log("[proxy.Provider.parseProxyInfo]: ProxyBypass=\"%s\", targetUrl=%s, bypass=%t", proxyBypass, targetUrl, bypass)
 		if bypass {
 			return nil, nil
 		}

--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -58,7 +58,7 @@ func (p *providerWindows) GetProxy(protocol string, targetUrlStr string) Proxy {
 	if len(proxies) == 0 {
 		return nil
 	}
-	return proxies[len(proxies) - 1]
+	return proxies[len(proxies)-1]
 }
 
 /*
@@ -117,7 +117,7 @@ func (p *providerWindows) GetProxies(protocol string, targetUrlStr string) []Pro
 	targetUrl := ParseTargetURL(targetUrlStr, protocol)
 	proxy := p.provider.get(protocol, targetUrl)
 	if proxy != nil {
-		return  []Proxy{proxy}
+		return []Proxy{proxy}
 	}
 	proxies := p.readWinHttpProxy(protocol, targetUrl)
 	return proxies
@@ -140,7 +140,7 @@ func (p *providerWindows) readWinHttpProxy(protocol string, targetUrl *url.URL) 
 	// Internet Options
 	ieProxyConfig, err := p.getIeProxyConfigCurrentUser()
 	if err != nil {
-		log.Printf("[proxy.Provider.readWinHttpProxy] Failed to read IE proxy config: %s\n", err)
+		p.log("[proxy.Provider.readWinHttpProxy] Failed to read IE proxy config: %s\n", err)
 	} else {
 		defer p.freeWinHttpResource(ieProxyConfig)
 		if ieProxyConfig.FAutoDetect {
@@ -148,7 +148,7 @@ func (p *providerWindows) readWinHttpProxy(protocol string, targetUrl *url.URL) 
 			if err == nil {
 				return proxy
 			} else if !isNotFound(err) {
-				log.Printf("[proxy.Provider.readWinHttpProxy] No proxy discovered via AutoDetect: %s\n", err)
+				p.log("[proxy.Provider.readWinHttpProxy] No proxy discovered via AutoDetect: %s\n", err)
 			}
 		}
 		if autoConfigUrl := winhttp.LpwstrToString(ieProxyConfig.LpszAutoConfigUrl); autoConfigUrl != "" {
@@ -156,7 +156,7 @@ func (p *providerWindows) readWinHttpProxy(protocol string, targetUrl *url.URL) 
 			if err == nil {
 				return proxies
 			} else if !isNotFound(err) {
-				log.Printf("[proxy.Provider.readWinHttpProxy] No proxy discovered via AutoConfigUrl, %s: %s\n", autoConfigUrl, err)
+				p.log("[proxy.Provider.readWinHttpProxy] No proxy discovered via AutoConfigUrl, %s: %s\n", autoConfigUrl, err)
 			}
 		}
 		// LpszProxy may contain multiple proxies which needs to be parsed into a list of Proxy
@@ -164,7 +164,7 @@ func (p *providerWindows) readWinHttpProxy(protocol string, targetUrl *url.URL) 
 		if err == nil {
 			return proxies
 		} else if !isNotFound(err) {
-			log.Printf("[proxy.Provider.readWinHttpProxy] Failed to parse named proxy: %s\n", err)
+			p.log("[proxy.Provider.readWinHttpProxy] Failed to parse named proxy: %s\n", err)
 		}
 	}
 	// netsh winhttp
@@ -172,7 +172,7 @@ func (p *providerWindows) readWinHttpProxy(protocol string, targetUrl *url.URL) 
 	if err == nil {
 		return proxies
 	} else if !isNotFound(err) {
-		log.Printf("[proxy.Provider.readWinHttpProxy] Failed to parse WinHttp default proxy info: %s\n", err)
+		p.log("[proxy.Provider.readWinHttpProxy] Failed to parse WinHttp default proxy info: %s\n", err)
 	}
 	return nil
 }
@@ -333,7 +333,7 @@ func (p *providerWindows) parseProxyInfo(src string, protocol string, targetUrl 
 	for _, proxyUrlStr := range proxyUrlStrList {
 		proxyUrl, err := ParseURL(proxyUrlStr, "")
 		if err != nil {
-			log.Printf("Failed to parse proxy URL\"$\"", proxyUrlStr)
+			p.log("Failed to parse proxy URL\"$\"", proxyUrlStr)
 			continue
 		}
 		pr, _ := NewProxy(proxyUrl, src)
@@ -401,7 +401,7 @@ Params:
 */
 func (p *providerWindows) closeHandle(h winhttp.HInternet) {
 	if err := winhttp.CloseHandle(h); err != nil {
-		log.Printf("[proxy.Provider.closeHandle] Failed to close handle \"%d\": %s\n", h, err)
+		p.log("[proxy.Provider.closeHandle] Failed to close handle \"%d\": %s\n", h, err)
 	}
 }
 
@@ -415,6 +415,6 @@ func (p *providerWindows) freeWinHttpResource(r winhttp.Allocated) {
 		return
 	}
 	if err := r.Free(); err != nil {
-		log.Printf("[proxy.Provider.readWinHttp] Failed to free struct \"%s\": %s\n", reflect.TypeOf(r), err)
+		p.log("[proxy.Provider.readWinHttp] Failed to free struct \"%s\": %s\n", reflect.TypeOf(r), err)
 	}
 }

--- a/proxy/provider_windows.go
+++ b/proxy/provider_windows.go
@@ -14,7 +14,6 @@ package proxy
 
 import (
 	"github.com/rapid7/go-get-proxied/winhttp"
-	"log"
 	"net/url"
 	"reflect"
 	"strings"


### PR DESCRIPTION
## Description
This PR adds a new `Provider` interface method `SetLog`, which allows the library user to toggle logging inside the provider.

All log calls are now routed through `provider.log` which checks if logging is enabled before logging.

Logging is set to `true` by default to ensure that logging does not stop unexpectedly for existing users.

`main.go` has been tweaked to use this new method.

## Testing
Tested in a proprietary app in which we needed logs, but did not need logging from `go-get-proxied`.
