### PR TITLE
ENDPOINT-19744: Uplift Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rapid7/go-get-proxied
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Description
https://rapid7.atlassian.net/browse/ENDPOINT-19744

Bump go.mod from 1.25.7 to 1.26.5 to address CVEs reported in DNR-12160. One-line change; go mod tidy, go mod vendor, and go vet all pass clean. Release tag v1.4.1 to follow after merge.

## Changes
- `go.mod`: go 1.25.7 → 1.26.5

## Related PRs
- rapid7/PyForensicsAgent#3144
- rapid7/jenkins-endpoint-shared-libraries#1218

## Related Tickets
- [ENDPOINT-14199](https://rapid7.atlassian.net/browse/ENDPOINT-14199) — [Snyk][Bootstrap] Address HIGH/MEDIUM vulnerabilities

## Snyk Verification

Verified on branch:
```
$ snyk test --file=go.mod
✔ Tested go-get-proxied for known issues, no vulnerable paths found.
```

[ENDPOINT-14199]: https://rapid7.atlassian.net/browse/ENDPOINT-14199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ